### PR TITLE
fix: wait unlimitness for slack

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -45,7 +45,10 @@ settings = Settings()
 
 async def send_deployment_success_to_slack(delay: int = 60):
     event_at = datetime.now(tz=timezone("Asia/Seoul")).strftime("%Y-%m-%d %H:%M:%S")
-    for _ in range(3):
+    if settings.slack_webhook_url == "invalid":
+        return
+
+    for _ in range(60):
         await asyncio.sleep(delay)
         res = requests.post(
             url=settings.slack_webhook_url,


### PR DESCRIPTION
## Why?

- 서비스가 활성화 되기까지 20개가 넘는 healthcheck 로그가 보임
- 이를 통해 10초마다 작동하는 healthcheck 에서 해당 함수가 3분을 넘어갈 수 있음

## How

- 60분간 대기하면서 계속 시도하고, 성공하는 순간 해당 코루틴을 중지하도록 설정