### PR TITLE
refactor: remove created_at in schema

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,3 @@
----
-name: base
-about: 간단한 형식의 PR 템플릿
-title: ""
----
-
 ## Why?
 
 ## How

--- a/backend/app/api/sensor_record.py
+++ b/backend/app/api/sensor_record.py
@@ -39,7 +39,7 @@ async def list_sensor_record(
 
 
 @router.post("")
-async def retrieve_sensor(body: SensorRecordCreateRequest = Body(...)):
+async def create_sensor_record(body: SensorRecordCreateRequest = Body(...)):
     with SessionLocal() as session:
         stmt = select(Sensor).where(Sensor.uuid == body.uuid)
         sensor = session.execute(stmt).scalar_one_or_none()

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -18,7 +18,6 @@ class SensorRecordCreateRequest(BaseModel):
     uuid: UUID4
     temperature: float
     humidity: float
-    created_at: datetime
 
 
 class SensorRecordListParam(BaseModel):


### PR DESCRIPTION
## Why?

- created_at 은 서버에서 부여하기 때문에 보낼 필요가 없습니다.
- 함수 한개의 이름이 잘못되어있습니다.

## How

- schema에서 해당 필드를 제외합니다.
- 함수의 이름을 수정합니다.