### PR TITLE
refactor: fix venv cache(ci), fix mantainence(cron)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Integration Test (Pytest)
 
 on:
   pull_request:
@@ -48,7 +48,7 @@ jobs:
         uses: actions/cache@v3
         name: cache virtualenv
         with:
-          path: ./.venv
+          path: backend/.venv
           key: venv-${{ hashFiles('poetry.lock') }}
       - 
         name: Install the project dependencies

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,4 +1,4 @@
-name: delete-old-lightsail-images
+name: CRON
 
 on:
   schedule:
@@ -11,7 +11,7 @@ env:
   SERVICE_NAME: cu-container-service-1
 
 jobs:
-  cron:
+  lightsail-maintenance:
     runs-on: ubuntu-latest
 
     steps:
@@ -29,7 +29,7 @@ jobs:
         name: Delete old lightsail images
         run: |
           IMAGES=$(aws lightsail get-container-images --service-name $SERVICE_NAME | jq -r '.containerImages[] | .image')
-          IMAGES_TO_DELETE=$(echo IMAGES | tail -n + 4)
+          IMAGES_TO_DELETE=$(echo $IMAGES | tail -n +4)
           for IMAGE in $IMAGES_TO_DELETE
           do
             aws lightsail delete-container-image --service-name $SERVICE_NAME --image $IMAGE

--- a/.github/workflows/lightsail.yml
+++ b/.github/workflows/lightsail.yml
@@ -1,4 +1,4 @@
-name: Build and push lightsail and deploy
+name: Build, Push, Deploy (Lightsail)
 
 on:
   push:
@@ -15,7 +15,7 @@ env:
   DB_URL: ${{ secrets.DB_URL }}
 
 jobs:
-  build:
+  build-push-deploy:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Why?

- venv 가 캐시되지 않아 CI가 오래 걸리고 있었습니다.
- cron 이 정상적으로 작동되지 않습니다.

## How

- cache path를 수정합니다. repo/.venv 를 repo/backend/.venv 로 변경해봅니다.
- cron에서 스페이스, $ 탈락과 같은 문법오류를 수정합니다.
