### PR TITLE
fix: fix cors variable format

### DIFF
--- a/.github/workflows/lightsail.yml
+++ b/.github/workflows/lightsail.yml
@@ -13,7 +13,7 @@ env:
   BACKEND_ENV: prod
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   DB_URL: ${{ secrets.DB_URL }}
-  ALLOW_ORIGINS: noname2048.dev
+  ALLOW_ORIGINS: '["noname2048.dev"]'
 
 jobs:
   build-push-deploy:

--- a/backend/.env.local
+++ b/backend/.env.local
@@ -1,4 +1,4 @@
 version="local"
 backend_env="local"
 db_url="postgresql://postgres:postgres@localhost:5432/"
-allow_origins="*"
+allow_origins=["*"]


### PR DESCRIPTION
## Why?

- allow_origins 에 noname2048.dev 를 기입해야 프론트에서 사용할 수 있음
- aws lightsail에서 배포할때는, 이를 json에 담아 보내고 있음
- json에 담기 위해서 github에서 선언하여 만듦.
- 여기에서 "['noname2048.dev']" 등을 넣는 것이 힘듦
  1. jq에서 스크립트를 넣어서 만들고 있어서 ' ... "['noname2048']"' 등으로 복잡하게 넣어야 함(기능이 동작은 함)
  2. 문제는 json 자체인데, lightsail-deploy.json 에서 environment 가 string 형태로만 받기 때문에 1번과 같은 문제로 문제를 풀 수 없고, 이스케이프를 통해 문자열로 넣어야함
  3. 문제가 더 복잡해짐...

## How

- config.py 에서 환경변수 타입을 list -> str 로 변경하고 서버 시작시에 split 함수를 통해 직접 나눠주기로 함
