### PR TITLE
fix: fix cors to include protocol

### DIFF
--- a/.github/workflows/lightsail.yml
+++ b/.github/workflows/lightsail.yml
@@ -13,7 +13,7 @@ env:
   BACKEND_ENV: prod
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   DB_URL: ${{ secrets.DB_URL }}
-  ALLOW_ORIGINS: noname2048.dev
+  ALLOW_ORIGINS: https://noname2048.dev
 
 jobs:
   build-push-deploy:

--- a/backend/.env.local
+++ b/backend/.env.local
@@ -1,4 +1,4 @@
 version="local"
 backend_env="local"
 db_url="postgresql://postgres:postgres@localhost:5432/"
-allow_origins="localhost:3000"
+allow_origins="http://localhost:3000"


### PR DESCRIPTION
## Why?

- origin 에는 protocol, port 번호를 포함하여 origin을 식별하므로, https, http 와 같은 프로토콜이 포함되어어 있어야 합니다.

## How

- noname2048.dev 에는 https 를, localhost:3000 에는 http를 추가합니다.